### PR TITLE
Configure deployment to Maven Central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import ReleaseTransformations._
+
 organization := "play-circe"
 
 name := "play-circe"
@@ -48,4 +50,33 @@ developers += Developer("jilen",
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 pomIncludeRepository := (_ => false)
+
+// Add sonatype repository settings
+publishTo := Some(
+  if (isSnapshot.value)
+    Opts.resolver.sonatypeSnapshots
+  else
+    Opts.resolver.sonatypeStaging
+)
+
+// release plugin
+
+releaseCrossBuild := true
+
+releasePublishArtifactsAction := PgpKeys.publishSigned.value // Use publishSigned in publishArtifacts step
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  publishArtifacts,
+  setNextVersion,
+  commitNextVersion,
+  releaseStepCommand("sonatypeReleaseAll"),
+  pushChanges
+)
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ libraryDependencies ++= {
   )
 }
 
-
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
 scalacOptions ++= Seq(
@@ -34,3 +33,19 @@ scalacOptions ++= Seq(
   "-Ywarn-value-discard",
   "-Xfuture",
   "-Ywarn-unused-import")
+
+// POM settings for Sonatype
+homepage := Some(url("https://github.com/jilen/play-circe"))
+
+scmInfo := Some(ScmInfo(url("https://github.com/jilen/play-circe"),
+  "git@github.com:jilen/play-circe.git"))
+
+developers += Developer("jilen",
+  "jilen",
+  "jilen.zhang@gmail.com",
+  url("https://github.com/jilen"))
+
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
+
+pomIncludeRepository := (_ => false)
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,8 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")


### PR DESCRIPTION
I configured sbt to deploy snapshots and releases to Sonatypo and via that to Maven Central.

You need to set up PGP keys and make an account at Sonatype. I've written a fairly detailed guide on my blog: https://leonard.io/blog/2017/01/an-in-depth-guide-to-deploying-to-maven-central/

(If you notice that something doesn't work let me know.)

You probably want to remove the bintray plugin.