### PR TITLE
fix warning

### DIFF
--- a/src/test/scala/play/api/libs/circe/Fakes.scala
+++ b/src/test/scala/play/api/libs/circe/Fakes.scala
@@ -64,7 +64,7 @@ trait Fakes {
       target = target,
       version = version,
       headers = Headers(hds: _*),
-      attrs = attrs + (RequestAttrKey.Id -> id)
+      attrs = attrs.updated(RequestAttrKey.Id -> id)
     )
   }
 }


### PR DESCRIPTION
```
[warn] -- Deprecation Warning: /home/runner/work/play-circe/play-circe/src/test/scala/play/api/libs/circe/Fakes.scala:67:20 
[warn] 67 |      attrs = attrs + (RequestAttrKey.Id -> id)
[warn]    |              ^^^^^^^
[warn]    |method + in trait TypedMap is deprecated since 2.9.0: Use `updated` instead.
```